### PR TITLE
Fix canonicalization: should be without comments

### DIFF
--- a/spec/fixtures/input_3_c14n_comments.xml
+++ b/spec/fixtures/input_3_c14n_comments.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0"?>
-<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:wsurandom="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
   <s:Header>
     <a:Action s:mustUnderstand="1">http://tempuri.org/IDocumentService/SearchDocuments</a:Action>
     <a:MessageID>urn:uuid:30db5d4f-ab84-46be-907c-be690a92979b</a:MessageID>
-    <a:ReplyTo>
-      <a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
-    </a:ReplyTo>
     <To xmlns="http://www.w3.org/2005/08/addressing" xmlns:a="http://www.w3.org/2003/05/soap-envelope" a:mustUnderstand="1">http://tempuri.org/PublicServices/Test/1.0.12/PublicServices/DocumentService.svc</To>
     <o:Security xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" s:mustUnderstand="1">
-      <wsurandom:Timestamp>
-        <wsurandom:Created>2012-05-02T18:17:14.467Z</wsurandom:Created>
-        <wsurandom:Expires>2012-05-02T18:22:14.467Z</wsurandom:Expires>
-      </wsurandom:Timestamp>
+      <u:Timestamp>
+        <u:Created>2012-05-02T18:17:14.467Z</u:Created>
+        <u:Expires>2012-05-02T18:22:14.467Z</u:Expires>
+      </u:Timestamp>
     </o:Security>
   </s:Header>
   <s:Body>
     <SearchDocuments xmlns="http://tempuri.org/">
       <searchCriteria xmlns:b="http://schemas.datacontract.org/2004/07/BusinessLogic.Data.Documents.Integration" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+        <!-- This comment shouldn't affect digest value for digested node -->
         <b:RegistrationNo>1</b:RegistrationNo>
       </searchCriteria>
     </SearchDocuments>

--- a/spec/fixtures/output_1.xml
+++ b/spec/fixtures/output_1.xml
@@ -38,15 +38,8 @@
               <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
               <DigestValue>3UQ13wcqsZOqwueVE7DfSmTGQ9c=</DigestValue>
           </Reference>
-          <Reference URI="#_0a595d505192b7525d46ab20a4773ea0b3191d23">
-            <Transforms>
-              <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
-            </Transforms>
-            <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-            <DigestValue>Pe9mMs3hjPi10puwjphEn+VzmV8=</DigestValue>
-          </Reference>
         </SignedInfo>
-        <SignatureValue>l88yAfUHBuiG7rqok+YQ6FI+RiF0A6/jRT3wqaLU/nuPXCZhJo9+nNh20gaJJmSIBSKb+n6uUD/vu4psUuaFMyHHk3zKyNZ9PlFeNf5zkVnkbdt90AiQW5b65uT1eVohzhRrqc4CvSsEpqxL8pUU5nsmedQZphBE12U6r08Zn3I=</SignatureValue>
+        <SignatureValue>BB0CHnd4qA8AVSj/xXrfK29Xa1aCmA9K+X4Bkvc2IsLOmfprXTrSHSb0maEKkFHFCLKH+DEIgCWtDC4rkyiXR5i8iKKZGggoMfD/2Wmw3TcARiQ2pyGrZA04NXTPWHo17nYwBQDhfhafeIKE4zFRXltyW/I/RRO678E3Fd1Ma0Y=</SignatureValue>
         <KeyInfo>
           <o:SecurityTokenReference>
             <o:Reference ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" URI="#uuid-639b8970-7644-4f9e-9bc4-9c2e367808fc-1"/>
@@ -55,10 +48,9 @@
       </Signature>
     </o:Security>
   </s:Header>
-  <s:Body wsurandom:Id="_0a595d505192b7525d46ab20a4773ea0b3191d23">
+  <s:Body>
     <SearchDocuments xmlns="http://tempuri.org/">
       <searchCriteria xmlns:b="http://schemas.datacontract.org/2004/07/BusinessLogic.Data.Documents.Integration" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-        <!-- This comment shouldn't be accounted when digesting -->
         <b:RegistrationNo>1</b:RegistrationNo>
       </searchCriteria>
     </SearchDocuments>

--- a/spec/fixtures/output_3_c14n_comments.xml
+++ b/spec/fixtures/output_3_c14n_comments.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing"
+            xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+  <s:Header>
+    <a:Action s:mustUnderstand="1">http://tempuri.org/IDocumentService/SearchDocuments</a:Action>
+    <a:MessageID>urn:uuid:30db5d4f-ab84-46be-907c-be690a92979b</a:MessageID>
+    <To xmlns="http://www.w3.org/2005/08/addressing" xmlns:a="http://www.w3.org/2003/05/soap-envelope" a:mustUnderstand="1">http://tempuri.org/PublicServices/Test/1.0.12/PublicServices/DocumentService.svc</To>
+    <o:Security xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+                s:mustUnderstand="1">
+      <u:Timestamp>
+        <u:Created>2012-05-02T18:17:14.467Z</u:Created>
+        <u:Expires>2012-05-02T18:22:14.467Z</u:Expires>
+      </u:Timestamp>
+      <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <SignedInfo>
+          <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+          <Reference URI="#_f7a662fdba7cdb44426d7447f06adf0f11707eeb">
+            <Transforms>
+              <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+            </Transforms>
+            <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <DigestValue>iqiXdxdsix9HMz4rEBEo/sYazDU=</DigestValue>
+          </Reference>
+        </SignedInfo>
+        <SignatureValue>XOMmCzcg7Un+BpWIP5WpAAeT1Sq2B+WZ8eM4MiDR1bhIFV8aPScAXX/cB3Esa88JcBltsiBlZTdq1hCQ8GKrLEvWTFMhkSCQrkAR+3eCUR894UzPrWTr0jYA7RZaVaw+XODf7ICbYIhLs7n50cPyFrslKVOjh6EKlCq1ZV5XFYE=</SignatureValue>
+      </Signature>
+    </o:Security>
+  </s:Header>
+  <s:Body u:Id="_f7a662fdba7cdb44426d7447f06adf0f11707eeb">
+    <SearchDocuments xmlns="http://tempuri.org/">
+      <searchCriteria xmlns:b="http://schemas.datacontract.org/2004/07/BusinessLogic.Data.Documents.Integration" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+        <!-- This comment shouldn't affect digest value for digested node -->
+        <b:RegistrationNo>1</b:RegistrationNo>
+      </searchCriteria>
+    </SearchDocuments>
+  </s:Body>
+</s:Envelope>


### PR DESCRIPTION
Currently used canonicalization method algorithm `http://www.w3.org/2001/10/xml-exc-c14n#` assumes that all comments are removed during canonicalization. But now it's not true. So, if there is comments inside digested node, the digest will be calculated incorrectly. See http://www.w3.org/TR/2002/REC-xml-exc-c14n-20020718/#sec-Use

It's a little fix to Nokogiri's `canonicalize` method invocation. While it's unclear from the nokogiri docs, but third argument should be exactly `nil` to remove comments from canonicalized result, but by default it's `false`. This inconsistence seems to be fixed in upcoming Nokogiri 1.6.2.
