### PR TITLE
SMEV 3 signing ability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Specify your gem's dependencies in signer.gemspec
 gemspec
 
 gem "jruby-openssl", :platforms => :jruby
+gem 'xml-normalizer', github: 'Imomoi/xml_normalizer_rb'

--- a/lib/signer.rb
+++ b/lib/signer.rb
@@ -17,8 +17,6 @@ class Signer
   WSSE_NAMESPACE = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'.freeze
   DS_NAMESPACE = 'http://www.w3.org/2000/09/xmldsig#'.freeze
 
-  SMEV_GOV_RU = -1
-
   SIGNATURE_ALGORITHM = {
     # SHA 1
     sha1: {
@@ -63,11 +61,6 @@ class Signer
       value: Nokogiri::XML::XML_C14N_1_1,
       id: 'https://www.w3.org/TR/2008/REC-xml-c14n11-20080502/'
     },
-    smev_gov_ru: {
-      name: 'SMEV GOV RU',
-      value: SMEV_GOV_RU,
-      id: 'urn://smev-gov-ru/xmldsig/transform'
-    }
   }.freeze
 
   def initialize(document, noblanks: true, wss: true, canonicalize_algorithm: :c14n_exec_1_0)

--- a/lib/signer/digester.rb
+++ b/lib/signer/digester.rb
@@ -28,6 +28,12 @@ class Signer
       id: 'http://www.w3.org/2001/04/xmldsig-more#gostr3411',
       digester: lambda { OpenSSL::Digest.new('md_gost94') },
     },
+    # GOST R 34-11 2012
+    gostr34112012: {
+      name: 'GOST R 34.11-2012',
+      id: 'urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr34112012-256',
+      digester: lambda { OpenSSL::Digest.new('streebog256') },
+    },
   }.freeze
 
   # Class that holds +OpenSSL::Digest+ instance with some meta information for digesting in XML.


### PR DESCRIPTION
Hi.

I've added ability to sign SMEV 3 SOAP requests and GOST R 34.10-2012 signature support. Take a look, please, does this code comfort you or it should be implemented some diffrent way?
The main difference with SMEV 2 (which is already supported) is a new XML Transform algorithm "urn://smev-gov-ru/xmldsig/transform", which is applied after standard C14N. I've implemented it as a flag for digest!() method (this was the simplest way), but it also might me implemented as a new canonicalization algorighm (then Signer should be able to support multiple canonicalization algorithms for digesting) and that would be a breaking change.
If this code is OK, I would also update README to point out the whole example code for SMEV 3 signing before merging this pull request.