### PR TITLE
Refactor digest!() method for better extensibility, add GOST-R 34.10/11-2012 algorithms, fix digest node ID reference, cleanup

### DIFF
--- a/lib/signer/digester.rb
+++ b/lib/signer/digester.rb
@@ -28,6 +28,12 @@ class Signer
       id: 'http://www.w3.org/2001/04/xmldsig-more#gostr3411',
       digester: lambda { OpenSSL::Digest.new('md_gost94') },
     },
+    # GOST R 34-11 2012 256 bit
+    gostr34112012_256: {
+      name: 'GOST R 34.11-2012 256',
+      id: 'urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr34112012-256',
+      digester: lambda { begin OpenSSL::Digest.new('streebog256') rescue OpenSSL::Digest.new('md_gost12_256') end },
+    },
   }.freeze
 
   # Class that holds +OpenSSL::Digest+ instance with some meta information for digesting in XML.


### PR DESCRIPTION
Implemented everything that we discussed in #21. I also made some cleanups with signature algorythm setup. I would also remove cert=() method (tries to guess appropriate signature algorythm) because it does no actually work as expected. It relies on certificate signature algorithm (CAs private key algorithm) which might not equal to certificate public key algorithm, which we are actually interrested in. But it's removal might break some existing applications, so I left it for now. 