### PR TITLE
Fix namespace issue for BinarySecurityToken tag

### DIFF
--- a/lib/signer.rb
+++ b/lib/signer.rb
@@ -196,6 +196,7 @@ class Signer
       node['EncodingType'] = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary'
       node.content = Base64.encode64(cert.to_der).gsub("\n", '')
       signature_node.add_previous_sibling(node)
+      set_namespace_for_node(node, WSSE_NAMESPACE, ds_namespace_prefix)
       wsse_ns = namespace_prefix(node, WSSE_NAMESPACE, 'wsse')
       wsu_ns = namespace_prefix(node, WSU_NAMESPACE, 'wsu')
       node["#{wsu_ns}:Id"] = security_token_id

--- a/lib/signer.rb
+++ b/lib/signer.rb
@@ -196,7 +196,7 @@ class Signer
       node['EncodingType'] = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary'
       node.content = Base64.encode64(cert.to_der).gsub("\n", '')
       signature_node.add_previous_sibling(node)
-      set_namespace_for_node(node, WSSE_NAMESPACE, ds_namespace_prefix)
+      set_namespace_for_node(node, WSSE_NAMESPACE, ds_namespace_prefix) if ([1, 12, 0] <=> Nokogiri::VERSION.split('.').map{|v| v.to_i}) <= 0
       wsse_ns = namespace_prefix(node, WSSE_NAMESPACE, 'wsse')
       wsu_ns = namespace_prefix(node, WSU_NAMESPACE, 'wsu')
       node["#{wsu_ns}:Id"] = security_token_id


### PR DESCRIPTION
In nokogiri `1.12.0` the following change was introduced:
> [CRuby] Reparented nodes no longer inherit their parent's namespace. Previously, a node without a namespace was forced to adopt its parent's namespace. [https://github.com/sparklemotion/nokogiri/issues/1712, https://github.com/sparklemotion/nokogiri/issues/425]

It seems like the `BinarySecurityToken` was implicitly relying on this to add the `wsse:` prefix which is no longer happening. This PR fixes it by explicitly adding the namespace.