### PR TITLE
Ensure compatibility with Nokogiri

### DIFF
--- a/lib/signer.rb
+++ b/lib/signer.rb
@@ -65,6 +65,7 @@ class Signer
     self.document = Nokogiri::XML(document.to_s) do |config|
       config.noblanks if noblanks
     end
+    self.document.namespace_inheritance = true if self.document.respond_to?(:namespace_inheritance)
     self.digest_algorithm = :sha1
     self.wss = wss
     self.canonicalize_algorithm = canonicalize_algorithm

--- a/signer.gemspec
+++ b/signer.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
 
-  gem.add_runtime_dependency 'nokogiri', '>= 1.5.1'
+  gem.add_runtime_dependency 'nokogiri', '>= 1.5.1', '!=1.12.3', '!=1.12.2', '!=1.12.1', '!=1.12.0'
 end


### PR DESCRIPTION
Nokogiri v1.12 introduced a breaking change related to namespace
inheritance of reparented child nodes. This commit using the feature added in
v1.12.4 to opt

- for new versions of Nokogiri that support it, set `Document#namespace_inheritance`
- intermediate versions of Nokogiri will be avoided via gemspec version specification
- old versions of Nokogiri will continue to work

See https://github.com/sparklemotion/nokogiri/issues/2320 for more details.

Fixes #30